### PR TITLE
Cross compile with Scala 2.11.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.pagerduty"
 
 name := "eris-core"
 
-scalaVersion := "2.10.4"
+crossScalaVersions := Seq("2.10.4", "2.11.7")
 
 publishArtifact in Test := true
 


### PR DESCRIPTION
This should be all that's needed right now, as all the dependencies support 2.10 and 2.11 as is.